### PR TITLE
Dependencies: Update jsx and remove msgpack

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,5 +9,5 @@
         {msgpack, ".*",
           {git, "git://github.com/msgpack/msgpack-erlang.git", "master"}},
         {jsx, ".*",
-          {git, "https://github.com/talentdeficit/jsx.git", "master"}}
+          {git, "https://github.com/talentdeficit/jsx.git", "main"}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -6,8 +6,6 @@
 {edoc_opts, [{dialyzer_specs, all}]}.
 
 {deps, [
-        {msgpack, ".*",
-          {git, "git://github.com/msgpack/msgpack-erlang.git", "master"}},
         {jsx, ".*",
           {git, "https://github.com/talentdeficit/jsx.git", "main"}}
        ]}.


### PR DESCRIPTION
- Update `jsx` dependency on Git branch from master to main since the upstream repo switched from master to main a while ago. Otherwise fetching the deps and building fails.
- Remove dependency on `msgpack` because:
  - It specifies the esoteric "git" protocol (port 9418) in the URL scheme, which causes problems with systems which block traffic on this port. (Could workaround this easily though by switching to "https" scheme.)
  - It's not compatible with the latest Erlang/OTP 22 or 23 releases.
